### PR TITLE
Fix for a crash that can occur if the phone hasn't an NFC chip

### DIFF
--- a/src/com/jmarroyo/apdusendercontactless/ApduSenderContactLess.java
+++ b/src/com/jmarroyo/apdusendercontactless/ApduSenderContactLess.java
@@ -792,7 +792,10 @@ public class ApduSenderContactLess extends Activity
         {
             icoCard.setImageResource(R.drawable.ic_icc_off);
         }
-        mAdapter.disableForegroundDispatch(this);
+        
+        if(mAdapter != null) {
+            mAdapter.disableForegroundDispatch(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
An exception could be thrown if the mAdapter variable is still null caused by the absence of an NFC chip on the device.